### PR TITLE
fix: tool missing on build

### DIFF
--- a/build/composer.sh
+++ b/build/composer.sh
@@ -2,14 +2,8 @@
 
 set -e
 
-if ! [ -z ${1+x} ]; then export COMPOSER_VERSION=${1}; fi
-
-if [ -z ${COMPOSER_VERSION+x} ]; then echo "No COMPOSER_VERSION defined - skipping" && exit; fi
-
-if ! [ -x "$(command -v php)" ]; then
-  echo "No php found - abborting"
-  exit 1
-fi
+check_version COMPOSER_VERSION
+check_command php
 
 echo "Installing Composer $COMPOSER_VERSION";
 curl https://raw.githubusercontent.com/composer/getcomposer.org/76a7060ccb93902cd7576b67264ad91c8a2700e2/web/installer | php -- --version=$COMPOSER_VERSION --install-dir=/usr/local/bin --filename=composer

--- a/build/composer.sh
+++ b/build/composer.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-check_version COMPOSER_VERSION
 check_command php
 
 echo "Installing Composer $COMPOSER_VERSION";

--- a/build/golang.sh
+++ b/build/golang.sh
@@ -2,11 +2,9 @@
 
 set -e
 
-check_version GOLANG_VERSION
-
 apt-get update && apt-get install -y bzr mercurial && rm -rf /var/lib/apt/lists/*
 
-curl -s https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz --output go.tgz
+curl -s https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz --output go.tgz
 tar -C /usr/local -xzf go.tgz
 rm go.tgz
 

--- a/build/golang.sh
+++ b/build/golang.sh
@@ -2,9 +2,7 @@
 
 set -e
 
-if ! [ -z ${1+x} ]; then export GOLANG_VERSION=${1}; fi
-
-if [ -z ${GOLANG_VERSION+x} ]; then echo "No GOLANG_VERSION defined - skipping" && exit; else echo "Installing Golang $GOLANG_VERSION"; fi
+check_version GOLANG_VERSION
 
 apt-get update && apt-get install -y bzr mercurial && rm -rf /var/lib/apt/lists/*
 

--- a/build/golang.sh
+++ b/build/golang.sh
@@ -24,6 +24,6 @@ echo GOSUMDB=off >> /usr/local/docker/env
 echo PATH="/usr/local/go/bin:$GOPATH/bin:\$PATH" >> /usr/local/docker/env
 
 refreshenv
-create_wrapper go
+shell_wrapper go
 
 go version

--- a/build/golang.sh
+++ b/build/golang.sh
@@ -22,3 +22,8 @@ echo CGO_ENABLED=0 >> /usr/local/docker/env
 echo GOPROXY=direct >> /usr/local/docker/env
 echo GOSUMDB=off >> /usr/local/docker/env
 echo PATH="/usr/local/go/bin:$GOPATH/bin:\$PATH" >> /usr/local/docker/env
+
+refreshenv
+create_wrapper go
+
+go version

--- a/build/gradle.sh
+++ b/build/gradle.sh
@@ -17,6 +17,7 @@ curl -sL -o gradle.zip https://services.gradle.org/distributions/gradle-$GRADLE_
 unzip -d /usr/local gradle.zip
 rm gradle.zip
 
-ln -sf /usr/local/gradle-$GRADLE_VERSION/bin/gradle /usr/local/bin/
+refreshenv
+link_wrapper gradle
 
 gradle --version

--- a/build/gradle.sh
+++ b/build/gradle.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-check_version GOLANG_VERSION
+check_version GRADLE_VERSION
 check_command java
 
 echo "Installing gradle $GRADLE_VERSION"

--- a/build/gradle.sh
+++ b/build/gradle.sh
@@ -2,14 +2,8 @@
 
 set -e
 
-if ! [ -z ${1+x} ]; then export GRADLE_VERSION=${1}; fi
-
-if [ -z ${GRADLE_VERSION+x} ]; then echo "No GRADLE_VERSION defined - skipping" && exit; fi
-
-if ! [ -x "$(command -v java)" ]; then
-  echo "No java found - abborting"
-  exit 1
-fi
+check_version GOLANG_VERSION
+check_command java
 
 echo "Installing gradle $GRADLE_VERSION"
 

--- a/build/gradle.sh
+++ b/build/gradle.sh
@@ -2,12 +2,11 @@
 
 set -e
 
-check_version GRADLE_VERSION
 check_command java
 
 echo "Installing gradle $GRADLE_VERSION"
 
-curl -sL -o gradle.zip https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip
+curl -sL -o gradle.zip https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip
 unzip -d /usr/local gradle.zip
 rm gradle.zip
 

--- a/build/install-tool.sh
+++ b/build/install-tool.sh
@@ -5,10 +5,8 @@
 TOOL="/usr/local/build/${1}.sh"
 shift;
 
-refreshenv
-
 if [ -f "$TOOL" ]; then
-  $TOOL $@
+  . $TOOL $@
 else
    echo "No tool defined - skipping"
    echo $TOOL

--- a/build/install-tool.sh
+++ b/build/install-tool.sh
@@ -2,25 +2,24 @@
 
 . /usr/local/build/util.sh
 
-TOOLNAME=${1^^}
+TOOLNAME=${1}
 TOOL="/usr/local/build/${1}.sh"
 shift;
 
 if [ ! -f "$TOOL" ]; then
-  echo "No tool defined - skipping"
-  echo $TOOL
+  echo "No tool defined - skipping: ${TOOLNAME}"
   exit 1;
 fi
 
 VERSION=${1}
 shift;
 
-ENVNAME=${TOOLNAME}_VERSION
+ENVNAME=${TOOLNAME^^}_VERSION
 
-if [ -z ${!ENVNAME+x} ]; then
+if [ ${VERSION} ]; then
   export $ENVNAME=$VERSION
 fi
 
-refreshenv
+check_version ${ENVNAME}
 
 . $TOOL $@

--- a/build/java.sh
+++ b/build/java.sh
@@ -2,14 +2,7 @@
 
 set -e
 
-check_version JAVA_VERSION
-
-SEMVER_REGEX="^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))?(\.(0|[1-9][0-9]*))?$"
-
-if ! [[ "$JAVA_VERSION" =~ $SEMVER_REGEX ]]; then
-  echo Not a semver tag - skipping: ${JAVA_VERSION}
-  exit
-fi
+check_semver $JAVA_VERSION
 
 apt-get update
 apt-get install -y openjdk-${BASH_REMATCH[1]}-jdk-headless

--- a/build/java.sh
+++ b/build/java.sh
@@ -2,9 +2,7 @@
 
 set -e
 
-if ! [ -z ${1+x} ]; then export JAVA_VERSION=${1}; fi
-
-if [ -z ${JAVA_VERSION+x} ]; then echo "No JAVA_VERSION defined - skipping" && exit; else echo "Installing java $JAVA_VERSION"; fi
+check_version JAVA_VERSION
 
 SEMVER_REGEX="^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))?(\.(0|[1-9][0-9]*))?$"
 

--- a/build/node.sh
+++ b/build/node.sh
@@ -2,9 +2,7 @@
 
 set -e
 
-if ! [ -z ${1+x} ]; then export NODE_VERSION=${1}; fi
-
-if [ -z ${NODE_VERSION+x} ]; then echo "No NODE_VERSION defined - skipping" && exit; fi
+check_version NODE_VERSION
 
 SEMVER_REGEX="^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))?(\.(0|[1-9][0-9]*))?$"
 

--- a/build/node.sh
+++ b/build/node.sh
@@ -22,7 +22,12 @@ tar -C /usr/local -xf node.tar.xz
 rm node.tar.xz
 
 echo PATH="/usr/local/node-v${NODE_VERSION}-${NODE_DISTRO}/bin:\$PATH" >> /usr/local/docker/env
-export PATH="/usr/local/node-v${NODE_VERSION}-${NODE_DISTRO}/bin:$PATH"
+
+refreshenv
+
+link_wrapper node
+link_wrapper npm
+link_wrapper npx
 
 # update to latest node-gyp to fully support python3
 npm explore npm -g -- npm install node-gyp@latest

--- a/build/node.sh
+++ b/build/node.sh
@@ -2,15 +2,6 @@
 
 set -e
 
-check_version NODE_VERSION
-
-SEMVER_REGEX="^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))?(\.(0|[1-9][0-9]*))?$"
-
-if ! [[ "$NODE_VERSION" =~ $SEMVER_REGEX ]]; then
-  echo Not a semver tag - skipping: ${NODE_VERSION}
-  exit
-fi
-
 echo "Installing node $NODE_VERSION";
 
 NODE_DISTRO=linux-x64

--- a/build/npm.sh
+++ b/build/npm.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -z ${NPM_VERSION+x} ]; then echo "No NPM_VERSION defined - skipping" && exit; fi
+if ! [ -z ${NPM_VERSION+x} ]; then echo "No NPM_VERSION defined - skipping" && exit; fi
 
 if ! [ -x "$(command -v node)" ]; then
   echo "No node found - abborting"

--- a/build/npm.sh
+++ b/build/npm.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-check_version NPM_VERSION
 check_command node
 
 echo "Installing npm $NPM_VERSION"

--- a/build/npm.sh
+++ b/build/npm.sh
@@ -2,12 +2,8 @@
 
 set -e
 
-if ! [ -z ${NPM_VERSION+x} ]; then echo "No NPM_VERSION defined - skipping" && exit; fi
-
-if ! [ -x "$(command -v node)" ]; then
-  echo "No node found - abborting"
-  exit 1
-fi
+check_version NPM_VERSION
+check_command node
 
 echo "Installing npm $NPM_VERSION"
 

--- a/build/php.sh
+++ b/build/php.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-check_version PHP_VERSION
-
 echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" > /etc/apt/sources.list.d/ondrej-php.list
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 14AA40EC0831756756D7F66C4F4EA0AAE5267A6C
 apt-get update

--- a/build/php.sh
+++ b/build/php.sh
@@ -2,9 +2,7 @@
 
 set -e
 
-if ! [ -z ${1+x} ]; then export PHP_VERSION=${1}; fi
-
-if [ -z ${PHP_VERSION+x} ]; then echo "No PHP_VERSION defined - skipping" && exit; else echo "Installing PHP $PHP_VERSION"; fi
+check_version PHP_VERSION
 
 echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" > /etc/apt/sources.list.d/ondrej-php.list
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 14AA40EC0831756756D7F66C4F4EA0AAE5267A6C

--- a/build/pnpm.sh
+++ b/build/pnpm.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -z ${PNPM_VERSION+x} ]; then echo "No PNPM_VERSION defined - skipping" && exit; fi
+if ! [ -z ${PNPM_VERSION+x} ]; then echo "No PNPM_VERSION defined - skipping" && exit; fi
 
 if ! [ -x "$(command -v node)" ]; then
   echo "No node found - abborting"
@@ -12,5 +12,7 @@ fi
 echo "Installing pnpm $PNPM_VERSION"
 
 npm install -g pnpm@${PNPM_VERSION}
+
+link_wrapper yarn
 
 pnpm --version

--- a/build/pnpm.sh
+++ b/build/pnpm.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-check_version PNPM_VERSION
 check_command node
 
 echo "Installing pnpm $PNPM_VERSION"

--- a/build/pnpm.sh
+++ b/build/pnpm.sh
@@ -2,12 +2,8 @@
 
 set -e
 
-if ! [ -z ${PNPM_VERSION+x} ]; then echo "No PNPM_VERSION defined - skipping" && exit; fi
-
-if ! [ -x "$(command -v node)" ]; then
-  echo "No node found - abborting"
-  exit 1
-fi
+check_version PNPM_VERSION
+check_command node
 
 echo "Installing pnpm $PNPM_VERSION"
 

--- a/build/util.sh
+++ b/build/util.sh
@@ -13,3 +13,25 @@ function  refreshenv () {
   esac
   done < /usr/local/docker/env
 }
+
+refreshenv
+
+# use this if custom env is required, creates a shell wrapper to /usr/local/bin
+function create_wrapper () {
+  local FILE="/usr/local/bin/${1}"
+  cat > $FILE <<- EOM
+#!/bin/bash
+
+. /usr/local/build/util.sh
+
+${1} \${@}
+EOM
+chmod +x $FILE
+}
+
+# use this for simple symlink to /usr/local/bin
+function link_wrapper () {
+  local TARGET="/usr/local/bin/${1}"
+  local SOURCE=$(command -v ${1})
+  ln -sf $SOURCE $TARGET
+}

--- a/build/util.sh
+++ b/build/util.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 function  refreshenv () {
   while IFS="=" read -r key value; do
   case "$key" in
@@ -26,7 +25,7 @@ function shell_wrapper () {
 
 ${1} \${@}
 EOM
-chmod +x $FILE
+  chmod +x $FILE
 }
 
 # use this for simple symlink to /usr/local/bin
@@ -34,4 +33,19 @@ function link_wrapper () {
   local TARGET="/usr/local/bin/${1}"
   local SOURCE=$(command -v ${1})
   ln -sf $SOURCE $TARGET
+}
+
+
+function check_version () {
+  if [ -z ${!1+x} ]; then
+    echo "No ${1} defined - aborting"
+    exit 1
+  fi
+}
+
+function check_command () {
+  if  ! [ -x "$(command -v ${1})" ]; then
+    echo "No ${1} defined - aborting"
+    exit 1
+  fi
 }

--- a/build/util.sh
+++ b/build/util.sh
@@ -17,7 +17,7 @@ function  refreshenv () {
 refreshenv
 
 # use this if custom env is required, creates a shell wrapper to /usr/local/bin
-function create_wrapper () {
+function shell_wrapper () {
   local FILE="/usr/local/bin/${1}"
   cat > $FILE <<- EOM
 #!/bin/bash

--- a/build/util.sh
+++ b/build/util.sh
@@ -38,14 +38,24 @@ function link_wrapper () {
 
 function check_version () {
   if [ -z ${!1+x} ]; then
-    echo "No ${1} defined - aborting"
+    echo "No ${1} defined - aborting: ${!1}"
     exit 1
   fi
 }
 
 function check_command () {
-  if  ! [ -x "$(command -v ${1})" ]; then
+  if  [ ! -x "$(command -v ${1})" ]; then
     echo "No ${1} defined - aborting"
+    exit 1
+  fi
+}
+
+
+SEMVER_REGEX="^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))?(\.(0|[1-9][0-9]*))?$"
+
+function check_semver () {
+  if [[ ! "${1}" =~ ${SEMVER_REGEX} ]]; then
+    echo Not a semver like version - aborting: ${1}
     exit 1
   fi
 }

--- a/build/yarn.sh
+++ b/build/yarn.sh
@@ -5,7 +5,6 @@ set -e
 check_version YARN_VERSION
 check_command node
 
-
 echo "Installing yarn $YARN_VERSION"
 
 npm install -g yarn@${YARN_VERSION}

--- a/build/yarn.sh
+++ b/build/yarn.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-check_version YARN_VERSION
 check_command node
 
 echo "Installing yarn $YARN_VERSION"

--- a/build/yarn.sh
+++ b/build/yarn.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -z ${1+x} ]; then export YARN_VERSION=${1}; fi
+if ! [ -z ${1+x} ]; then export YARN_VERSION=${1}; fi
 
 if [ -z ${YARN_VERSION+x} ]; then echo "No YARN_VERSION defined - skipping" && exit; fi
 
@@ -15,5 +15,7 @@ echo "Installing yarn $YARN_VERSION"
 
 npm install -g yarn@${YARN_VERSION}
 echo PATH="/home/ubuntu/.yarn/bin:\$PATH" >> /usr/local/docker/env
+
+link_wrapper yarn
 
 yarn --version

--- a/build/yarn.sh
+++ b/build/yarn.sh
@@ -2,14 +2,9 @@
 
 set -e
 
-if ! [ -z ${1+x} ]; then export YARN_VERSION=${1}; fi
+check_version YARN_VERSION
+check_command node
 
-if [ -z ${YARN_VERSION+x} ]; then echo "No YARN_VERSION defined - skipping" && exit; fi
-
-if ! [ -x "$(command -v node)" ]; then
-  echo "No node found - abborting"
-  exit 1
-fi
 
 echo "Installing yarn $YARN_VERSION"
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,6 +2,4 @@
 
 . /usr/local/build/util.sh
 
-refreshenv
-
 exec "$@"


### PR DESCRIPTION
This failed before, because `RUN` command don't read our `env`
```Dockerfile
FROM renovate/buildpack

RUN install-tool node 12.16.2

RUN npm --version
```

ref: renovatebot/docker-renovate#8

closes: #8 