### PR TITLE
feat: Add common php extensions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        test: [poetry, cocoapods, pipenv, golang, mix, node]
+        test: [poetry, cocoapods, pipenv, golang, mix, node, php]
 
     timeout-minutes: 10
 

--- a/src/php/build/php.sh
+++ b/src/php/build/php.sh
@@ -5,4 +5,4 @@ set -e
 echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" > /etc/apt/sources.list.d/ondrej-php.list
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 14AA40EC0831756756D7F66C4F4EA0AAE5267A6C
 
-apt_install php${PHP_VERSION}-cli php${PHP_VERSION}-mbstring php${PHP_VERSION}-curl
+apt_install php${PHP_VERSION}-cli php${PHP_VERSION}-mbstring php${PHP_VERSION}-curl php${PHP_VERSION}-xml php${PHP_VERSION}-json

--- a/test/php/Dockerfile
+++ b/test/php/Dockerfile
@@ -1,0 +1,34 @@
+ARG IMAGE=renovate/buildpack
+FROM ${IMAGE}
+
+
+# renovate: datasource=docker versioning=docker
+RUN install-tool php 7.4
+
+
+USER ubuntu
+
+SHELL [ "/bin/sh", "-c" ]
+ENTRYPOINT [ ]
+
+RUN set -ex; \
+  printenv; \
+  echo $SHELL; \
+  echo "$(command -v php)";
+
+RUN set -ex; \
+  [ "$(command -v php)" = "/usr/bin/php" ] && echo "php installed" || exit 1;
+
+RUN set -ex; \
+  $(php -r 'exit(extension_loaded("mbstring") ? 0 : 1);') && echo "php-mbstring installed" || exit 1;
+
+RUN set -ex; \
+  $(php -r 'exit(extension_loaded("curl") ? 0 : 1);') && echo "php-curl installed" || exit 1;
+
+RUN set -ex; \
+  $(php -r 'exit(extension_loaded("xml") ? 0 : 1);') && echo "php-xml installed" || exit 1;
+
+RUN set -ex; \
+  $(php -r 'exit(extension_loaded("json") ? 0 : 1);') && echo "php-json installed" || exit 1;
+
+RUN php --version


### PR DESCRIPTION
In very common projects using symfony, there is a `cache:clear` command which is ran after `composer update`. This command requires DOM extension.

```
Script cache:clear returned with error code 1
!!  
!!  In XmlUtils.php line 50:
!!                                
!!    Extension DOM is required.
```