### PR TITLE
feat(node): support node v15

### DIFF
--- a/src/base/build/util.sh
+++ b/src/base/build/util.sh
@@ -26,8 +26,14 @@ function shell_wrapper () {
   cat > $FILE <<- EOM
 #!/bin/bash
 
-if [[ -f \$BASH_ENV ]]; then
+if [[ -f "\$BASH_ENV" ]]; then
   . \$BASH_ENV
+fi
+
+if [[ "\$(command -v ${1})" == "$FILE" ]]; then
+  echo Could not forward ${1}, probably wrong PATH variable.
+  echo PATH=\$PATH
+  exit 1
 fi
 
 ${1} \${@}

--- a/src/node/build/node.sh
+++ b/src/node/build/node.sh
@@ -2,23 +2,51 @@
 
 set -e
 
+check_semver $NODE_VERSION
+
+if [[ ! "${MAJOR}" || ! "${MINOR}" ]]; then
+  echo Invalid version: ${NODE_VERSION}
+  exit 1
+fi
+
+
 NODE_DISTRO=linux-x64
+NODE_INSTALL_DIR=/usr/local/node/${NODE_VERSION}
+
+if [[ -d "${NODE_INSTALL_DIR}" ]]; then
+  echo "Skipping, already installed"
+  exit 0
+fi
+
+
+mkdir -p $NODE_INSTALL_DIR
 
 curl -sLo node.tar.xz https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${NODE_DISTRO}.tar.xz
-tar -C /usr/local -xf node.tar.xz
+tar -C ${NODE_INSTALL_DIR} --strip 1 -xf node.tar.xz
 rm node.tar.xz
 
-export_path "/usr/local/node-v${NODE_VERSION}-${NODE_DISTRO}/bin"
+export_path "${NODE_INSTALL_DIR}/bin"
 
-# update to latest node-gyp to fully support python3
-npm explore npm -g -- npm install node-gyp@latest
+if [[ ${MAJOR} < 15 ]]; then
+  # update to latest node-gyp to fully support python3
+  npm explore npm -g -- npm install --cache /tmp/empty-cache node-gyp@latest
+fi
 
-echo node: $(node --version)
-echo npm: $(npm --version)
+echo node: $(node --version) $(command -v node)
+echo npm: $(npm --version)  $(command -v npm)
 
-# backward compatibillity
-shell_wrapper node
+if [[ ${MAJOR} < 15 ]]; then
+  # backward compatibillity
+  shell_wrapper node
+fi
+
+NPM_CONFIG_PREFIX="/home/ubuntu/.npm-global"
+
+# npm 7 bug
+mkdir -p $NPM_CONFIG_PREFIX/{bin,lib}
+chown -R ubuntu $NPM_CONFIG_PREFIX
+chmod -R g+w $NPM_CONFIG_PREFIX
 
 # redirect user install
-export_env NPM_CONFIG_PREFIX "/home/ubuntu/.npm-global"
+export_env NPM_CONFIG_PREFIX $NPM_CONFIG_PREFIX
 export_path "\$NPM_CONFIG_PREFIX/bin"

--- a/test/node/Dockerfile
+++ b/test/node/Dockerfile
@@ -5,11 +5,11 @@ FROM ${IMAGE} as build
 # renovate: datasource=docker versioning=docker
 RUN install-tool node 12.16.2
 
-
 RUN touch /.dummy
 
 USER ubuntu
 
+COPY --chown=ubuntu:0 test test
 
 #--------------------------------------
 # test: node
@@ -29,17 +29,20 @@ RUN set -ex; \
 
 RUN node --version
 
-
 #--------------------------------------
 # test: yarn
 #--------------------------------------
 FROM build as testb
+
 
 RUN npm install -g yarn
 
 RUN set -ex; \
   [ "$(command -v yarn)" = "/home/ubuntu/.npm-global/bin/yarn" ] && echo "works" || exit 1; \
   yarn --version;
+
+
+RUN set -ex; cd test/a; yarn
 
 
 ENV NPM_CONFIG_PREFIX=/tmp/.npm
@@ -62,16 +65,56 @@ RUN install-tool pnpm 4.14.2
 
 USER ubuntu
 
+
 RUN set -ex; \
   pnpm --version; \
   command -v pnpm;
 
 
+RUN set -ex; cd test/a; pnpm i
+
+#--------------------------------------
+# test: node 15
+#--------------------------------------
+
+FROM ${IMAGE} as testd
+
+RUN install-tool node 15.0.1
+
+RUN touch /.dummy
+
+RUN install-tool yarn 1.22.5
+
+USER ubuntu
+
+COPY --chown=ubuntu:0 test test
+
+RUN set -ex; \
+  npm --version; \
+  command -v npm;
+
+
+RUN set -ex; cd test/a; npm i
+
+RUN npm install -g yarn
+RUN set -ex; \
+  [ "$(command -v yarn)" = "/home/ubuntu/.npm-global/bin/yarn" ] && echo "works" || exit 1; \
+  yarn --version;
+
+RUN mkdir -p /tmp/.npm/{bin,lib}
+ENV NPM_CONFIG_PREFIX=/tmp/.npm
+RUN npm install -g yarn
+
+RUN set -ex; \
+  [ "$(command -v yarn)" = "/tmp/.npm/bin/yarn" ] && echo "works" || exit 1; \
+  yarn --version;
+
 #--------------------------------------
 # final
 #--------------------------------------
-FROM build
+FROM ${IMAGE}
 
 COPY --from=testa /.dummy /.dummy
 COPY --from=testb /.dummy /.dummy
 COPY --from=testc /.dummy /.dummy
+COPY --from=testd /.dummy /.dummy

--- a/test/node/test/a/package.json
+++ b/test/node/test/a/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "semver": "7.3.2"
+  }
+}


### PR DESCRIPTION
* add workaround for npm v7
* move node install from `/usr/local/node-12.0.1-linux-x64` to `/usr/local/node/12.0.1`
* `$NODE_VERSION` semver check
* catch shell wrapper endless recursion
* skip reinstall same node version

closes renovatebot/docker-node#48