### PR TITLE
Added bazelisk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,14 @@ COPY src/dotnet/ /usr/local/
 
 
 #--------------------------------------
+# Image: bazel
+#--------------------------------------
+FROM base as bazel
+
+COPY src/bazel/ /usr/local/
+
+
+#--------------------------------------
 # Image: erlang
 #--------------------------------------
 FROM base as target-erlang
@@ -136,6 +144,7 @@ COPY src/swift/ /usr/local/
 #--------------------------------------
 FROM base as target-latest
 
+COPY src/bazel/ /usr/bazel/
 COPY src/docker/ /usr/local/
 COPY src/dotnet/ /usr/local/
 COPY src/erlang/ /usr/local/

--- a/src/bazel/buildpack/tools/bazel.sh
+++ b/src/bazel/buildpack/tools/bazel.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+check_semver ${BAZELISK_VERSION}
+
+
+if [[ ! "${MAJOR}" || ! "${MINOR}" || ! "${PATCH}" ]]; then
+  echo Invalid version: ${BAZELISK_VERSION}
+  exit 1
+fi
+
+if [[ -d "/usr/local/bazel/${BAZELISK_VERSION}" ]]; then
+  echo "Skipping, already installed"
+  exit 0
+fi
+
+# bazel depends on
+apt_install git diff patch
+
+mkdir -p /usr/local/bazel/${BAZELISK_VERSION}
+curl -sSL https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-amd64 --output /usr/local/bazel/${BAZELISK_VERSION}/bazelisk
+
+export_path "/usr/local/bazelisk/${BAZELISK_VERSION}"
+
+bazelisk version

--- a/test/bazel/Dockerfile
+++ b/test/bazel/Dockerfile
@@ -1,0 +1,9 @@
+ARG IMAGE=renovate/buildpack
+FROM ${IMAGE} as build
+
+# renovate: datasource=github-releases lookupName=bazelbuild/bazelisk
+RUN install-tool bazelisk 1.7.5
+
+USER ubuntu
+
+RUN set -ex; bazelisk version


### PR DESCRIPTION
When renovate is used together with Bazel repositories, there may be
some certain Bazel targets needed to be run for each dependencies
upgrade.

A good example would be upgrading go.mod file inside a Bazel-Gazelle
setup would require Gazelle to be run after go.mod and go.sum update to
also update the dependencies tracked inside WORKSPACE files (or linked
starlark files).

Add bazelisk into the toolchain so that renovate-full image could be
used for such situations.

Close https://github.com/renovatebot/docker-buildpack/issues/51

---

Small note:
I am not too familiar with the structure and usage of this repo. Looking forward for pointers from the maintainers.