### PR TITLE
fix(dotnet): fix and simplify installer

### DIFF
--- a/src/dotnet/build/dotnet.sh
+++ b/src/dotnet/build/dotnet.sh
@@ -24,11 +24,18 @@ case "$VERSION_CODENAME" in
 esac
 
 
-mkdir -p /usr/local/dotnet
-curl -sfL https://dot.net/v1/dotnet-install.sh | bash -s - --version $DOTNET_VERSION --install-dir ${DOTNET_INSTALL_DIR}
+mkdir -p $DOTNET_INSTALL_DIR
+arch=linux-x64
+url=https://dotnetcli.azureedge.net/dotnet/Sdk/${DOTNET_VERSION}/dotnet-sdk-${DOTNET_VERSION}-${arch}.tar.gz
+curl -sfL  --output dotnet.tgz $url
+tar --strip 1 -C $DOTNET_INSTALL_DIR -xzf dotnet.tgz
 
 export_path "${DOTNET_INSTALL_DIR}"
 export_env DOTNET_ROOT "${DOTNET_INSTALL_DIR}"
 export_env DOTNET_CLI_TELEMETRY_OPTOUT "1"
 
-dotnet help
+# first time experience
+dotnet help > /dev/null
+su $USER_NAME -c 'dotnet help' > /dev/null
+
+dotnet --info

--- a/test/dotnet/Dockerfile
+++ b/test/dotnet/Dockerfile
@@ -1,20 +1,34 @@
 ARG IMAGE=renovate/buildpack
-FROM ${IMAGE} as build
+FROM ${IMAGE} as base
 
-# renovate: datasource=docker versioning=docker
-RUN install-tool dotnet 3.1.403
-
-# renovate: datasource=docker versioning=docker
-RUN install-tool dotnet 3.1.403
+RUN touch /.dummy
 
 WORKDIR /tmp
 
-USER 1000
-
 COPY --chown=1000:0 test test
 
+
+#--------------------------------------
+# net3: dotnet 3.1 base image
+#--------------------------------------
+FROM base as net3
+
+# renovate: datasource=docker lookupName=mcr.microsoft.com/dotnet/sdk versioning=docker
+RUN install-tool dotnet 3.1.403
+
+# renovate: datasource=docker lookupName=mcr.microsoft.com/dotnet/sdk versioning=docker
+RUN install-tool dotnet 3.1.403
+
+USER 1000
+
 RUN set -ex; \
-    dotnet help
+    dotnet --info
+
+
+#--------------------------------------
+# test: dotnet 3.1
+#--------------------------------------
+FROM net3 as testa
 
 RUN set -ex; \
     cd test; \
@@ -24,3 +38,32 @@ RUN set -ex;  \
     cd test; \
     dotnet add package Newtonsoft.Json --version 12.0.3; \
     dotnet restore --force-evaluate
+
+
+#--------------------------------------
+# test: dotnet 5.0
+#--------------------------------------
+FROM base as testb
+
+# renovate: datasource=docker lookupName=mcr.microsoft.com/dotnet/sdk versioning=docker
+RUN install-tool dotnet 5.0.102
+
+USER 1000
+
+RUN set -ex; \
+    cd test; \
+    dotnet restore --use-lock-file
+
+RUN set -ex;  \
+    cd test; \
+    dotnet add package Newtonsoft.Json --version 12.0.3; \
+    dotnet restore --force-evaluate
+
+
+#--------------------------------------
+# final
+#--------------------------------------
+FROM base
+
+COPY --from=testa /.dummy /.dummy
+COPY --from=testb /.dummy /.dummy


### PR DESCRIPTION
The official ms install script currently fails.

This pr uses now the direct downloads to install the dotnet sdk, like the official docker images do.