### PR TITLE
fix: specify full path to bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ LABEL maintainer="Rhys Arkins <rhys@arkins.net>" \
 
 #  autoloading buildpack env
 ENV BASH_ENV=/usr/local/etc/env
-SHELL ["bash" , "-c"]
+SHELL ["/bin/bash" , "-c"]
 
 COPY src/base/ /usr/local/
 


### PR DESCRIPTION
Docker alternatives like Kaniko require specifying the full path to the shell executable.

Without this change a simple `Dockerfile` like this:

```Dockerfile
FROM renovate/renovate:slim

# Uncomment to fix locally
# SHELL ["/bin/bash" , "-c"]

RUN echo "Hello world"
```

Will fail when built with Kaniko:

```shell
➜ docker run -v /Users/fgreinacher/Code/localhost/renovate-test:/workspace gcr.io/kaniko-project/executor --no-push --context dir:///workspace --cleanup --cache=false
INFO[0000] Retrieving image manifest renovate/renovate:slim 
INFO[0000] Retrieving image renovate/renovate:slim from registry index.docker.io 
INFO[0001] Built cross stage deps: map[]                
INFO[0001] Retrieving image manifest renovate/renovate:slim 
INFO[0001] Returning cached image manifest              
INFO[0001] Executing 0 build triggers                   
INFO[0001] Unpacking rootfs as cmd RUN echo "Hello world" requires it. 
INFO[0019] RUN echo "Hello world"                       
INFO[0019] Taking snapshot of full filesystem...        
INFO[0023] cmd: bash                                    
INFO[0023] args: [-c echo "Hello world"]                
INFO[0023] util.Lookup returned: &{Uid:1000 Gid:0 Username:ubuntu Name: HomeDir:/home/ubuntu} 
INFO[0023] performing slow lookup of group ids for ubuntu 
INFO[0023] Running: [bash -c echo "Hello world"]        
error building image: error building stage: failed to execute command: starting command: exec: "bash": executable file not found in $PATH
```