### PR TITLE
fix: update binary builder changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![Build status](https://github.com/renovatebot/docker-buildpack/workflows/build/badge.svg)
 ![Docker Image Size (latest)](https://img.shields.io/docker/image-size/renovate/buildpack/latest)
+![GitHub](https://img.shields.io/github/license/renovatebot/docker-buildpack)
+
 
 # docker-buildpack
 

--- a/src/python/buildpack/tools/python.sh
+++ b/src/python/buildpack/tools/python.sh
@@ -4,7 +4,6 @@ set -e
 
 check_semver ${TOOL_VERSION}
 
-PYTHON_URL="https://raw.githubusercontent.com/renovatebot/python/releases"
 
 if [[ ! "${MAJOR}" || ! "${MINOR}" || ! "${PATCH}" ]]; then
   echo Invalid version: ${TOOL_VERSION}
@@ -23,13 +22,14 @@ if [[ -z "${tool_path}" ]]; then
   base_path=${INSTALL_DIR}/${TOOL_NAME}
   tool_path=${base_path}/${TOOL_VERSION}
 
-  VERSION_ID=$(. /etc/os-release && echo ${VERSION_ID})
-
   mkdir -p ${base_path}
 
   file=/tmp/python.tar.xz
 
-  curl -sSfLo ${file} ${PYTHON_URL}/${VERSION_ID}/python-${TOOL_VERSION}.tar.xz || echo 'Ignore download error'
+  CODENAME=$(. /etc/os-release && echo ${VERSION_CODENAME})
+  PYTHON_URL="https://github.com/renovatebot/ruby/releases/download"
+
+  curl -sSfLo ${file} ${PYTHON_URL}/${TOOL_VERSION}/python-${TOOL_VERSION}-${CODENAME}.tar.xz || echo 'Ignore download error'
 
   if [[ -f ${file} ]]; then
     echo 'Using prebuild python'

--- a/src/python/buildpack/tools/python.sh
+++ b/src/python/buildpack/tools/python.sh
@@ -27,7 +27,7 @@ if [[ -z "${tool_path}" ]]; then
   file=/tmp/python.tar.xz
 
   CODENAME=$(. /etc/os-release && echo ${VERSION_CODENAME})
-  PYTHON_URL="https://github.com/renovatebot/ruby/releases/download"
+  PYTHON_URL="https://github.com/renovatebot/python/releases/download"
 
   curl -sSfLo ${file} ${PYTHON_URL}/${TOOL_VERSION}/python-${TOOL_VERSION}-${CODENAME}.tar.xz || echo 'Ignore download error'
 

--- a/src/ruby/buildpack/tools/ruby.sh
+++ b/src/ruby/buildpack/tools/ruby.sh
@@ -18,7 +18,7 @@ fi
 
 mkdir -p /usr/local/ruby
 
-CODENAME=$(. /etc/os-release && echo ${VERSION_ID})
+CODENAME=$(. /etc/os-release && echo ${VERSION_CODENAME})
 RUBY_URL="https://github.com/renovatebot/ruby/releases/download"
 
 curl -sSfLo ruby.tar.xz ${RUBY_URL}/${TOOL_VERSION}/ruby-${TOOL_VERSION}-${CODENAME}.tar.xz || echo 'Ignore download error'

--- a/test/python/Dockerfile
+++ b/test/python/Dockerfile
@@ -10,7 +10,7 @@ COPY --chown=1000:0 test test
 FROM base as build
 
 # Python
-# renovate: datasource=docker
+# renovate: datasource=github-releases lookupName=renovatebot/python
 RUN install-tool python 3.9.1
 
 
@@ -18,7 +18,7 @@ FROM base as build-rootless
 
 USER 1000
 
-# renovate: datasource=docker
+# renovate: datasource=github-releases lookupName=renovatebot/python
 RUN install-tool python 3.9.1
 
 #--------------------------------------
@@ -48,7 +48,7 @@ USER 1000
 FROM build as testa
 
 # try install again, sould skip
-# renovate: datasource=docker
+# renovate: datasource=github-releases lookupName=renovatebot/python
 RUN install-tool python 3.9.1
 
 # renovate: datasource=pypi

--- a/test/ruby/Dockerfile
+++ b/test/ruby/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /tmp
 
 FROM ${IMAGE} as build3
 
-# renovate: datasource=ruby-version lookupName=ruby-version versioning=ruby
+# renovate: datasource=github-releases lookupName=renovatebot/ruby versioning=ruby
 RUN install-tool ruby 3.0.0
 
 RUN touch /.dummy


### PR DESCRIPTION
- binary packages are now build as `<toolname>-<version>-<codename>.tar.xz` (ruby & python)
- update python to use gh releases