### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This repository is the source for the Docker Hub image `renovate/buildpack`. Com
 
 ## Notice: Do not use the language docker tags
 
-Do not use the language docker tags, they are deprecated and won't be updated soon.
+Do not use the language docker tags like `renovate/buildpack:ruby` or `renovate/buildpack:5-ruby`, they are deprecated and won't be updated soon.
+Use `renovate/buildpack` or `renovate/buildpack:5` images but checkout latest version.
 
 ## Notice: Intention to Relocate
 


### PR DESCRIPTION
Deprecate language based docker tags, they are the same as the version only tags.
They only differ in metadata