### PR TITLE
fix: Revert "test(deps): update dotnet docker tag to v6"

### DIFF
--- a/test/dotnet/Dockerfile
+++ b/test/dotnet/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /test
 FROM base as net3
 
 # renovate: datasource=docker lookupName=mcr.microsoft.com/dotnet/sdk versioning=docker
-RUN install-tool dotnet 6.0.100
+RUN install-tool dotnet 3.1.415
 
 USER 1000
 


### PR DESCRIPTION
Reverts renovatebot/docker-buildpack#257