### PR TITLE
feat: do not publish docker language tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,6 +71,7 @@ jobs:
         run: docker build --build-arg IMAGE=${{ env.TEST_IMAGE }} ./test/${{ matrix.tag }}
 
       - name: Build and Publish
+        if: ${{ matrix.tag == 'latest' }}
         uses: renovatebot/internal-tools@453d93444a4992b80e8f09e7a4133316a690de0c # renovate: tag=v1.11.4
         with:
           command: docker-builder

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This repository is the source for the Docker Hub image `renovate/buildpack`. Com
 
 ## Notice: Do not use the language docker tags
 
-Do not use the language docker tags like `renovate/buildpack:ruby` or `renovate/buildpack:5-ruby`, they are deprecated and won't be updated soon.
-Use `renovate/buildpack` or `renovate/buildpack:5` images but checkout latest version.
+Do not use the language docker tags like `renovate/buildpack:ruby` or `renovate/buildpack:5-ruby`, they are deprecated and won't be updated.
+Use `renovate/buildpack` or `renovate/buildpack:6` images but checkout latest version.
 
 ## Notice: Intention to Relocate
 

--- a/builder.json
+++ b/builder.json
@@ -1,9 +1,9 @@
 {
   "image": "buildpack",
   "versioning": "docker",
-  "startVersion": "5",
-  "latestVersion": "5",
+  "startVersion": "6",
+  "latestVersion": "6",
   "cache": "docker-build-cache",
-  "versions": ["1", "2", "3", "4", "5"],
+  "versions": ["1", "2", "3", "4", "5", "6"],
   "forceUnstable": true
 }


### PR DESCRIPTION
BREAKING CHANGE: Docker language tags are no longer published.
Use the normal version tags.